### PR TITLE
docs: 登记 dsh-chat-import

### DIFF
--- a/docs/plugins/sessions-memory.md
+++ b/docs/plugins/sessions-memory.md
@@ -363,3 +363,11 @@ Repository: `zimixvx/dsh-archive-manager`
 A minimal DeepSeek Harness Web plugin that lists archived sessions and permanently deletes an archived session directory after explicit confirmation.
 
 Install: `dsh plugin --profile web add github:zimixvx/dsh-archive-manager`
+
+### [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)
+
+Repository: `Nwflower/dsh-chat-import`
+
+Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.
+
+Install: `dsh plugin --profile web add github:Nwflower/dsh-chat-import`


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-chat-import |
| 仓库 | https://github.com/Nwflower/dsh-chat-import |
| 一句话说明 | 13 种编码 Agent 聊天记录全保真导入为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code |
| 版本 | 0.3.1（npm `dsh-chat-import`） |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [x] npm 已发布（0.1.0–0.3.1），340 测试 + CI 全绿
- [x] 13 个 `import_*` 工具 + `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import` 实测通过

## 改动内容

在 `docs/plugins/sessions-memory.md` 末尾追加条目块（`### [name]` + Repository + 描述 + Install 格式，与现有条目一致）：

```
### [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import)

Repository: `Nwflower/dsh-chat-import`

Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.

Install: `dsh plugin --profile web add github:Nwflower/dsh-chat-import`
```

> 说明：README 显示该分类计数为 45，追加后应为 46；如计数为自动生成，请维护者运行生成脚本同步。