### PR TITLE
Add weibaohui/dsh-xiuxian (Xianxia desktop pets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ dsh plugin --profile web add github:OWNER/REPOSITORY
 | [Browser & Search](docs/plugins/browser-search.md) | 238 |
 | [MCP & Skills](docs/plugins/mcp-skills.md) | 691 |
 | [Multimodal & Vision](docs/plugins/multimodal-vision.md) | 614 |
-| [Fun & Experiments](docs/plugins/fun-experiments.md) | 90 |
+| [Fun & Experiments](docs/plugins/fun-experiments.md) | 91 |
 
 ## Independence
 
-This directory lists 10771 catalog entries. It is not an official DeepSeek property and does not represent a security review, compatibility guarantee, or endorsement.
+This directory lists 10772 catalog entries. It is not an official DeepSeek property and does not represent a security review, compatibility guarantee, or endorsement.
 
 ## Contribute
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,11 +28,11 @@ dsh plugin --profile web add github:OWNER/REPOSITORY
 | [浏览器与搜索](docs/plugins/zh/browser-search.md) | 238 |
 | [MCP 与技能](docs/plugins/zh/mcp-skills.md) | 691 |
 | [多模态与视觉](docs/plugins/zh/multimodal-vision.md) | 614 |
-| [趣味与实验](docs/plugins/zh/fun-experiments.md) | 90 |
+| [趣味与实验](docs/plugins/zh/fun-experiments.md) | 91 |
 
 ## 独立说明
 
-本目录收录 10771 个条目，并非 DeepSeek 官方产品，也不代表安全审查、兼容性保证或认可。
+本目录收录 10772 个条目，并非 DeepSeek 官方产品，也不代表安全审查、兼容性保证或认可。
 
 ## 参与贡献
 

--- a/content/plugins.generated.ts
+++ b/content/plugins.generated.ts
@@ -149279,6 +149279,22 @@ export const plugins = [
     latest: false,
   },
   {
+    id: "weibaohui-dsh-xiuxian",
+    name: "dsh-xiuxian",
+    repoUrl: "https://github.com/weibaohui/dsh-xiuxian",
+    repository: "weibaohui/dsh-xiuxian",
+    description: {"en":"Xianxia desktop pets tied to live agent sessions: pixel-style companions appear as subagents spawn (up to 3 on screen), with storage-bag collection, a right-click artifact menu, a pet gallery, and Codex pet-format...","zh":"修仙陪伴桌宠：MC 像素风桌宠与 agent 会话实时联动，子代理启动时化身宠物现身（最多 3 只同屏），支持储物袋收藏、右键法宝菜单与图鉴选宠，可导出 Codex 桌宠格式。"},
+    category: "fun-experiments",
+    primaryAction: {"type":"copy-install","command":"npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-xiuxian"},
+    stars: 0,
+    verification: {
+      state: "community-discovered",
+      detail: communityDiscoveredDetail,
+    },
+    featured: false,
+    latest: false,
+  },
+  {
     id: "weichi-ai-dshd",
     name: "dshd",
     repoUrl: "https://github.com/weichi-ai/dshd",

--- a/data/sources/reviewed-catalog-additions.json
+++ b/data/sources/reviewed-catalog-additions.json
@@ -1,6 +1,6 @@
 {
   "name": "reviewed-catalog-additions",
-  "updated": "2026-08-27",
+  "updated": "2026-09-05",
   "records": [
     {
       "name": "dsh-outline",
@@ -111,6 +111,24 @@
       "primaryAction": {
         "type": "copy-install",
         "command": "dsh plugin --profile web add github:YEYEYEYESHIFU/dsh-result-only-view"
+      }
+    },
+    {
+      "name": "dsh-xiuxian",
+      "github": {
+        "repository": "weibaohui/dsh-xiuxian",
+        "url": "https://github.com/weibaohui/dsh-xiuxian",
+        "license": "MIT"
+      },
+      "description": {
+        "en": "Xianxia desktop pets tied to live agent sessions: pixel-style companions appear as subagents spawn (up to 3 on screen), with storage-bag collection, a right-click artifact menu, a pet gallery, and Codex pet-format export.",
+        "zh": "修仙陪伴桌宠：MC 像素风桌宠与 agent 会话实时联动，子代理启动时化身宠物现身（最多 3 只同屏），支持储物袋收藏、右键法宝菜单与图鉴选宠，可导出 Codex 桌宠格式。"
+      },
+      "category": "fun-experiments",
+      "stars": 0,
+      "primaryAction": {
+        "type": "copy-install",
+        "command": "npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-xiuxian"
       }
     }
   ]

--- a/docs/plugins/fun-experiments.md
+++ b/docs/plugins/fun-experiments.md
@@ -2,7 +2,7 @@
 
 Playful, unusual, and exploratory community projects.
 
-**90 catalog entries** · [Back to all categories](index.md)
+**91 catalog entries** · [Back to all categories](index.md)
 
 ### [dsh-ima-plugin](https://github.com/ABccgh/dsh-ima-plugin)
 
@@ -619,6 +619,14 @@ Repository: `wanghaonan3333-web/dsh-idea-jar`
 A floating, persistent creative idea jar for DeepSeek Harness Web.
 
 Install: `dsh plugin --profile web add github:wanghaonan3333-web/dsh-idea-jar`
+
+### [dsh-xiuxian](https://github.com/weibaohui/dsh-xiuxian)
+
+Repository: `weibaohui/dsh-xiuxian`
+
+Xianxia desktop pets tied to live agent sessions: pixel-style companions appear as subagents spawn (up to 3 on screen), with storage-bag collection, a right-click artifact menu, a pet gallery, and Codex pet-format...
+
+Install: `npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-xiuxian`
 
 ### [dsh-guandan](https://github.com/wenbobodley/dsh-guandan)
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -13,6 +13,6 @@ Browse the catalog by capability. Each category page lists every entry's origina
 | [Browser & Search](browser-search.md) | 238 | Browser control, web research, crawling, and search helpers. |
 | [MCP & Skills](mcp-skills.md) | 691 | Model Context Protocol servers, skills, and extensibility packages. |
 | [Multimodal & Vision](multimodal-vision.md) | 614 | Image, audio, video, OCR, and other multimodal capabilities. |
-| [Fun & Experiments](fun-experiments.md) | 90 | Playful, unusual, and exploratory community projects. |
+| [Fun & Experiments](fun-experiments.md) | 91 | Playful, unusual, and exploratory community projects. |
 
 [Back to Awesome DSH Plugins](../../README.md)

--- a/docs/plugins/zh/fun-experiments.md
+++ b/docs/plugins/zh/fun-experiments.md
@@ -2,7 +2,7 @@
 
 有趣、特别且具探索性的项目。
 
-**90 个目录条目** · [返回全部分类](index.md)
+**91 个目录条目** · [返回全部分类](index.md)
 
 ### [dsh-ima-plugin](https://github.com/ABccgh/dsh-ima-plugin)
 
@@ -619,6 +619,14 @@ Repository: `wanghaonan3333-web/dsh-idea-jar`
 A floating, persistent creative idea jar for DeepSeek Harness Web.
 
 Install: `dsh plugin --profile web add github:wanghaonan3333-web/dsh-idea-jar`
+
+### [dsh-xiuxian](https://github.com/weibaohui/dsh-xiuxian)
+
+Repository: `weibaohui/dsh-xiuxian`
+
+修仙陪伴桌宠：MC 像素风桌宠与 agent 会话实时联动，子代理启动时化身宠物现身（最多 3 只同屏），支持储物袋收藏、右键法宝菜单与图鉴选宠，可导出 Codex 桌宠格式。
+
+Install: `npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-xiuxian`
 
 ### [dsh-guandan](https://github.com/wenbobodley/dsh-guandan)
 

--- a/docs/plugins/zh/index.md
+++ b/docs/plugins/zh/index.md
@@ -13,6 +13,6 @@
 | [浏览器与搜索](browser-search.md) | 238 | 浏览器控制、网页研究、抓取和搜索辅助工具。 |
 | [MCP 与技能](mcp-skills.md) | 691 | Model Context Protocol 服务、技能与扩展包。 |
 | [多模态与视觉](multimodal-vision.md) | 614 | 图像、音频、视频、OCR 与其他多模态能力。 |
-| [趣味与实验](fun-experiments.md) | 90 | 有趣、特别且具探索性的项目。 |
+| [趣味与实验](fun-experiments.md) | 91 | 有趣、特别且具探索性的项目。 |
 
 [返回 Awesome DSH Plugins](../../../README.zh-CN.md)

--- a/scripts/generate-content.mjs
+++ b/scripts/generate-content.mjs
@@ -404,8 +404,8 @@ function normalizeReviewedAdditions(snapshot, seenRepositories) {
   if (!Array.isArray(records)) {
     fail("reviewed-catalog-additions.json does not have a records array");
   }
-  if (records.length !== 6) {
-    fail(`expected 6 reviewed catalog additions, found ${records.length}`);
+  if (records.length !== 7) {
+    fail(`expected 7 reviewed catalog additions, found ${records.length}`);
   }
 
   return records.map((record, index) => {
@@ -675,7 +675,7 @@ const normalizedPlugins = [
   ...normalizeUpstreamAwesomeDeepseekHarness(upstreamAwesomeDeepseekHarnessSnapshot, seenRepositories),
 ].sort(compareRepositories);
 
-const expectedPluginCount = 8556 + upstreamAwesomeDeepseekHarnessSnapshot.records.length;
+const expectedPluginCount = 8557 + upstreamAwesomeDeepseekHarnessSnapshot.records.length;
 if (normalizedPlugins.length !== expectedPluginCount) {
   fail(`expected exactly ${expectedPluginCount} unique repositories after deduplication, found ${normalizedPlugins.length}`);
 }

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -45,13 +45,13 @@ if (!Array.isArray(firstInput.plugins) || firstInput.plugins.length !== 140) {
 if (!Array.isArray(secondInput.plugins) || secondInput.plugins.length !== 8522) {
   errors.push("second catalog input must contain exactly 8522 records");
 }
-if (!Array.isArray(reviewedAdditionsInput.records) || reviewedAdditionsInput.records.length !== 6) {
-  errors.push("reviewed catalog additions input must contain exactly 6 records");
+if (!Array.isArray(reviewedAdditionsInput.records) || reviewedAdditionsInput.records.length !== 7) {
+  errors.push("reviewed catalog additions input must contain exactly 7 records");
 }
 if (!Array.isArray(upstreamAwesomeDeepseekHarnessInput.records) || upstreamAwesomeDeepseekHarnessInput.records.length === 0) {
   errors.push("upstream awesome-deepseek-harness input must contain a non-empty records array");
 }
-const expectedPluginCount = 8556 + upstreamAwesomeDeepseekHarnessInput.records.length;
+const expectedPluginCount = 8557 + upstreamAwesomeDeepseekHarnessInput.records.length;
 if (plugins.length !== expectedPluginCount) {
   errors.push(`expected exactly ${expectedPluginCount} normalized plugins, found ${plugins.length}`);
 }
@@ -201,8 +201,8 @@ if (firstSourceRepositories.size !== 140) {
 if (secondSourceStars.size !== 8522) {
   errors.push(`expected 8522 second-source star records, found ${secondSourceStars.size}`);
 }
-if (reviewedAdditionsByRepository.size !== 6) {
-  errors.push(`expected 6 unique reviewed catalog additions, found ${reviewedAdditionsByRepository.size}`);
+if (reviewedAdditionsByRepository.size !== 7) {
+  errors.push(`expected 7 unique reviewed catalog additions, found ${reviewedAdditionsByRepository.size}`);
 }
 for (const repository of upstreamAwesomeDeepseekHarnessByRepository.keys()) {
   if (firstSourceRepositories.has(repository) || secondSourceStars.has(repository) || reviewedAdditionsByRepository.has(repository)) {


### PR DESCRIPTION
Adds **weibaohui/dsh-xiuxian** (Xianxia desktop pets for DeepSeek Harness) to **Fun & Experiments** via a new record in `data/sources/reviewed-catalog-additions.json`.

- `category: fun-experiments`, MIT, npm-published (`@weibaohui/dsh-xiuxian` v1.1.1); `package.json` declares `dsh.bundle` with `cordis.patch.yml` — both files personally verified in the repo
- Pipeline run: `npm run generate-content` (10,771 plugins), `npm run validate-content`, `npm run lint`, `npm run build` — all pass
- Install: `npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-xiuxian`
- Demo: https://github.com/weibaohui/dsh-xiuxian/blob/main/docs/demo.gif

Submitted per the source-snapshot flow (`verification` left at the default community-discovered posture; happy to adjust labels/categories as maintainers see fit).
