### PR TITLE
Add weibaohui/dsh-continue (auto-resume for interrupted sessions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dsh plugin --profile web add github:OWNER/REPOSITORY
 | [UI & Themes](docs/plugins/ui-themes.md) | 286 |
 | [Sessions & Memory](docs/plugins/sessions-memory.md) | 934 |
 | [Tools & Capabilities](docs/plugins/tools-capabilities.md) | 4433 |
-| [Workflow & Agents](docs/plugins/workflow-agents.md) | 761 |
+| [Workflow & Agents](docs/plugins/workflow-agents.md) | 762 |
 | [Notifications & Integrations](docs/plugins/notifications-integrations.md) | 285 |
 | [Development & Runtime](docs/plugins/development-runtime.md) | 2439 |
 | [Browser & Search](docs/plugins/browser-search.md) | 238 |
@@ -32,7 +32,7 @@ dsh plugin --profile web add github:OWNER/REPOSITORY
 
 ## Independence
 
-This directory lists 10771 catalog entries. It is not an official DeepSeek property and does not represent a security review, compatibility guarantee, or endorsement.
+This directory lists 10772 catalog entries. It is not an official DeepSeek property and does not represent a security review, compatibility guarantee, or endorsement.
 
 ## Contribute
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@ dsh plugin --profile web add github:OWNER/REPOSITORY
 | [界面与主题](docs/plugins/zh/ui-themes.md) | 286 |
 | [会话与记忆](docs/plugins/zh/sessions-memory.md) | 934 |
 | [工具与能力](docs/plugins/zh/tools-capabilities.md) | 4433 |
-| [工作流与智能体](docs/plugins/zh/workflow-agents.md) | 761 |
+| [工作流与智能体](docs/plugins/zh/workflow-agents.md) | 762 |
 | [通知与集成](docs/plugins/zh/notifications-integrations.md) | 285 |
 | [开发与运行时](docs/plugins/zh/development-runtime.md) | 2439 |
 | [浏览器与搜索](docs/plugins/zh/browser-search.md) | 238 |
@@ -32,7 +32,7 @@ dsh plugin --profile web add github:OWNER/REPOSITORY
 
 ## 独立说明
 
-本目录收录 10771 个条目，并非 DeepSeek 官方产品，也不代表安全审查、兼容性保证或认可。
+本目录收录 10772 个条目，并非 DeepSeek 官方产品，也不代表安全审查、兼容性保证或认可。
 
 ## 参与贡献
 

--- a/content/plugins.generated.ts
+++ b/content/plugins.generated.ts
@@ -149263,6 +149263,22 @@ export const plugins = [
     latest: false,
   },
   {
+    id: "weibaohui-dsh-continue",
+    name: "dsh-continue",
+    repoUrl: "https://github.com/weibaohui/dsh-continue",
+    repository: "weibaohui/dsh-continue",
+    description: {"en":"Auto-resume for interrupted agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or...","zh":"自动续跑：agent 会话中断后自动续上，规则表按失败类型（限流/额度/鉴权/上下文超限/崩溃孤儿）路由到退避重试、换模型、压缩上下文后继续或止损通知，规则可视化编辑，全程活动日志。"},
+    category: "workflow-agents",
+    primaryAction: {"type":"copy-install","command":"npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-continue"},
+    stars: 0,
+    verification: {
+      state: "community-discovered",
+      detail: communityDiscoveredDetail,
+    },
+    featured: false,
+    latest: false,
+  },
+  {
     id: "weibaohui-dsh-plugin-scheduled-items",
     name: "dsh-plugin-scheduled-items",
     repoUrl: "https://github.com/weibaohui/dsh-plugin-scheduled-items",

--- a/data/sources/reviewed-catalog-additions.json
+++ b/data/sources/reviewed-catalog-additions.json
@@ -1,6 +1,6 @@
 {
   "name": "reviewed-catalog-additions",
-  "updated": "2026-08-27",
+  "updated": "2026-09-05",
   "records": [
     {
       "name": "dsh-outline",
@@ -111,6 +111,24 @@
       "primaryAction": {
         "type": "copy-install",
         "command": "dsh plugin --profile web add github:YEYEYEYESHIFU/dsh-result-only-view"
+      }
+    },
+    {
+      "name": "dsh-continue",
+      "github": {
+        "repository": "weibaohui/dsh-continue",
+        "url": "https://github.com/weibaohui/dsh-continue",
+        "license": "MIT"
+      },
+      "description": {
+        "en": "Auto-resume for interrupted agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or stop-loss notification, with a visual rule editor and activity log.",
+        "zh": "自动续跑：agent 会话中断后自动续上，规则表按失败类型（限流/额度/鉴权/上下文超限/崩溃孤儿）路由到退避重试、换模型、压缩上下文后继续或止损通知，规则可视化编辑，全程活动日志。"
+      },
+      "category": "workflow-agents",
+      "stars": 0,
+      "primaryAction": {
+        "type": "copy-install",
+        "command": "npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-continue"
       }
     }
   ]

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -7,7 +7,7 @@ Browse the catalog by capability. Each category page lists every entry's origina
 | [UI & Themes](ui-themes.md) | 286 | Interfaces, terminal clients, themes, and presentation improvements. |
 | [Sessions & Memory](sessions-memory.md) | 934 | Conversation history, context, persistence, and memory helpers. |
 | [Tools & Capabilities](tools-capabilities.md) | 4433 | Focused utilities and capability extensions for everyday work. |
-| [Workflow & Agents](workflow-agents.md) | 761 | Automation, orchestration, prompts, and agent workflows. |
+| [Workflow & Agents](workflow-agents.md) | 762 | Automation, orchestration, prompts, and agent workflows. |
 | [Notifications & Integrations](notifications-integrations.md) | 285 | Messaging, notifications, and connections to external services. |
 | [Development & Runtime](development-runtime.md) | 2439 | Developer tooling, shells, containers, testing, and runtime support. |
 | [Browser & Search](browser-search.md) | 238 | Browser control, web research, crawling, and search helpers. |

--- a/docs/plugins/workflow-agents.md
+++ b/docs/plugins/workflow-agents.md
@@ -2,7 +2,7 @@
 
 Automation, orchestration, prompts, and agent workflows.
 
-**761 catalog entries** · [Back to all categories](index.md)
+**762 catalog entries** · [Back to all categories](index.md)
 
 ### [dsh-prompt-boost](https://github.com/060625dfy/dsh-prompt-boost)
 
@@ -5235,6 +5235,14 @@ Repository: `Web0926/dsh-llm-verifier`
 DeepSeek Harness plugin that validates and ranks 3/5 independent coding-agent patches before approval-gated apply.
 
 Install: `dsh plugin --profile web add github:Web0926/dsh-llm-verifier`
+
+### [dsh-continue](https://github.com/weibaohui/dsh-continue)
+
+Repository: `weibaohui/dsh-continue`
+
+Auto-resume for interrupted agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or...
+
+Install: `npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-continue`
 
 ### [dsh-product-delivery-workflow](https://github.com/wellorbetter/dsh-product-delivery-workflow)
 

--- a/docs/plugins/zh/index.md
+++ b/docs/plugins/zh/index.md
@@ -7,7 +7,7 @@
 | [界面与主题](ui-themes.md) | 286 | 界面、终端客户端、主题和展示体验增强。 |
 | [会话与记忆](sessions-memory.md) | 934 | 对话历史、上下文、持久化与记忆辅助工具。 |
 | [工具与能力](tools-capabilities.md) | 4433 | 面向日常工作的实用工具和能力扩展。 |
-| [工作流与智能体](workflow-agents.md) | 761 | 自动化、编排、提示词与智能体工作流。 |
+| [工作流与智能体](workflow-agents.md) | 762 | 自动化、编排、提示词与智能体工作流。 |
 | [通知与集成](notifications-integrations.md) | 285 | 消息、通知以及外部服务连接。 |
 | [开发与运行时](development-runtime.md) | 2439 | 开发工具、Shell、容器、测试与运行时支持。 |
 | [浏览器与搜索](browser-search.md) | 238 | 浏览器控制、网页研究、抓取和搜索辅助工具。 |

--- a/docs/plugins/zh/workflow-agents.md
+++ b/docs/plugins/zh/workflow-agents.md
@@ -2,7 +2,7 @@
 
 自动化、编排、提示词与智能体工作流。
 
-**761 个目录条目** · [返回全部分类](index.md)
+**762 个目录条目** · [返回全部分类](index.md)
 
 ### [dsh-prompt-boost](https://github.com/060625dfy/dsh-prompt-boost)
 
@@ -5235,6 +5235,14 @@ Repository: `Web0926/dsh-llm-verifier`
 DeepSeek Harness plugin that validates and ranks 3/5 independent coding-agent patches before approval-gated apply.
 
 Install: `dsh plugin --profile web add github:Web0926/dsh-llm-verifier`
+
+### [dsh-continue](https://github.com/weibaohui/dsh-continue)
+
+Repository: `weibaohui/dsh-continue`
+
+自动续跑：agent 会话中断后自动续上，规则表按失败类型（限流/额度/鉴权/上下文超限/崩溃孤儿）路由到退避重试、换模型、压缩上下文后继续或止损通知，规则可视化编辑，全程活动日志。
+
+Install: `npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-continue`
 
 ### [dsh-product-delivery-workflow](https://github.com/wellorbetter/dsh-product-delivery-workflow)
 

--- a/scripts/generate-content.mjs
+++ b/scripts/generate-content.mjs
@@ -404,8 +404,8 @@ function normalizeReviewedAdditions(snapshot, seenRepositories) {
   if (!Array.isArray(records)) {
     fail("reviewed-catalog-additions.json does not have a records array");
   }
-  if (records.length !== 6) {
-    fail(`expected 6 reviewed catalog additions, found ${records.length}`);
+  if (records.length !== 7) {
+    fail(`expected 7 reviewed catalog additions, found ${records.length}`);
   }
 
   return records.map((record, index) => {
@@ -675,7 +675,7 @@ const normalizedPlugins = [
   ...normalizeUpstreamAwesomeDeepseekHarness(upstreamAwesomeDeepseekHarnessSnapshot, seenRepositories),
 ].sort(compareRepositories);
 
-const expectedPluginCount = 8556 + upstreamAwesomeDeepseekHarnessSnapshot.records.length;
+const expectedPluginCount = 8557 + upstreamAwesomeDeepseekHarnessSnapshot.records.length;
 if (normalizedPlugins.length !== expectedPluginCount) {
   fail(`expected exactly ${expectedPluginCount} unique repositories after deduplication, found ${normalizedPlugins.length}`);
 }

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -45,13 +45,13 @@ if (!Array.isArray(firstInput.plugins) || firstInput.plugins.length !== 140) {
 if (!Array.isArray(secondInput.plugins) || secondInput.plugins.length !== 8522) {
   errors.push("second catalog input must contain exactly 8522 records");
 }
-if (!Array.isArray(reviewedAdditionsInput.records) || reviewedAdditionsInput.records.length !== 6) {
-  errors.push("reviewed catalog additions input must contain exactly 6 records");
+if (!Array.isArray(reviewedAdditionsInput.records) || reviewedAdditionsInput.records.length !== 7) {
+  errors.push("reviewed catalog additions input must contain exactly 7 records");
 }
 if (!Array.isArray(upstreamAwesomeDeepseekHarnessInput.records) || upstreamAwesomeDeepseekHarnessInput.records.length === 0) {
   errors.push("upstream awesome-deepseek-harness input must contain a non-empty records array");
 }
-const expectedPluginCount = 8556 + upstreamAwesomeDeepseekHarnessInput.records.length;
+const expectedPluginCount = 8557 + upstreamAwesomeDeepseekHarnessInput.records.length;
 if (plugins.length !== expectedPluginCount) {
   errors.push(`expected exactly ${expectedPluginCount} normalized plugins, found ${plugins.length}`);
 }
@@ -201,8 +201,8 @@ if (firstSourceRepositories.size !== 140) {
 if (secondSourceStars.size !== 8522) {
   errors.push(`expected 8522 second-source star records, found ${secondSourceStars.size}`);
 }
-if (reviewedAdditionsByRepository.size !== 6) {
-  errors.push(`expected 6 unique reviewed catalog additions, found ${reviewedAdditionsByRepository.size}`);
+if (reviewedAdditionsByRepository.size !== 7) {
+  errors.push(`expected 7 unique reviewed catalog additions, found ${reviewedAdditionsByRepository.size}`);
 }
 for (const repository of upstreamAwesomeDeepseekHarnessByRepository.keys()) {
   if (firstSourceRepositories.has(repository) || secondSourceStars.has(repository) || reviewedAdditionsByRepository.has(repository)) {


### PR DESCRIPTION
Adds **weibaohui/dsh-continue (auto-resume)** (Auto-resume for interrupted agent sessions) to **Workflow Sessions & Memory Agents** via a new record in `data/sources/reviewed-catalog-additions.json`.

- `category: workflow-agents`, MIT, npm-published (`@weibaohui/dsh-continue (auto-resume)` v0.1.4); `package.json` declares `dsh.bundle` with `cordis.patch.yml` — both personally verified
- Pipeline: `generate-content` / `validate-content` / `lint` / `build` all pass (expected-count assertions in both scripts bumped 6→7 in lockstep, same as this repo's own sync flow)
- Install: `npx @deepseek-ai/dsh plugin --profile web add @weibaohui/dsh-continue (auto-resume)`
- Demo: https://github.com/weibaohui/dsh-continue (auto-resume)/blob/main/docs/demo.gif

> Note: I'm submitting one PR per plugin; sibling PRs touch the same generated artifacts and count assertions, so a rebase + script re-run may be needed depending on merge order.
